### PR TITLE
[#2] Import/export tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 bower_components
+g11n.csv
+g11n.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ Simply push your changes to a branch on your repository and submit a pull reques
 
 [manual.md](docs/manual.md) - a full guide to using angular-g11n.
 
+[managing-g11n-as-csv.md](docs/managing-g11n-as-csv.md) - you can manage g11n using CSV files if JSON doesn't suit you.
+
 [API.md](docs/API.md) - details of the methods available in the angular-g11n API.
 
 [LICENSE](LICENSE) - terms and conditions.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ angular-g11n
 
 [![Build Status](https://travis-ci.org/uor/angular-g11n.svg?branch=initial)](https://travis-ci.org/uor/angular-g11n)
 
-Simple globalization (internationalization + localization) for AngularJS. Developed by [Radify](http://radify.io). Allows you to manage your g11n in simple JSON format and to switch languages on the fly.
+Simple globalization (internationalization + localization) for AngularJS. Developed by [Radify](http://radify.io). Allows you to manage your g11n in simple JSON format and to switch languages on the fly. Also supports CSV import/export as a Gulp task.
 
 # Quickstart
 
@@ -68,6 +68,8 @@ This page is just to get you started, for more detail, see the pages below:
 [manual.md](docs/manual.md) - a full guide to using angular-g11n.
 
 [API.md](docs/API.md) - details of the methods available in the angular-g11n API.
+
+[managing-g11n-as-csv.md](docs/managing-g11n-as-csv.md) - you can manage g11n using CSV files if JSON doesn't suit you.
 
 [LICENSE](LICENSE) - terms and conditions.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -97,6 +97,8 @@ LocaleLoader('en_US').then(function(lang) {
 
 [manual.md](manual.md) - a full guide to using angular-g11n.
 
+[managing-g11n-as-csv.md](managing-g11n-as-csv.md) - you can manage g11n using CSV files if JSON doesn't suit you.
+
 [LICENSE](../LICENSE) - terms and conditions.
 
 [CONTRIBUTING.md](../CONTRIBUTING.md) - guide to contributing to angular-g11n.

--- a/docs/managing-g11n-as-csv.md
+++ b/docs/managing-g11n-as-csv.md
@@ -1,0 +1,72 @@
+# Managing g11n as CSV
+
+Although working with JSON is fine for most people, you may wish to manage your g11n as CSV. This has the following benefits:
+
+* You can see different locales side-by-side
+* You could send the CSV to a client to enter their copy without them needing to grok JSON
+
+Therefore, we have provided two Gulp tasks to do this: `export` and `import`. You must keep all your json g11n files in the same directory, and our tasks will take care of converting them to and from JSON.
+
+## Exporting to CSV
+
+### Custom input directory
+
+By default we're looking for translations files in './docs/sample/app/catalogs'. You can tell it where to look:
+
+```bash
+node_modules/gulp/bin/gulp.js export --inputDirectory=/var/www/my-app/app/js/catalogs
+```
+
+### Custom language list
+
+By default, it looks for en only.
+
+```bash
+node_modules/gulp/bin/gulp.js export --langs=en,izzle
+```
+
+### Custom output file
+
+By default, `export` will create g11n.csv. You can customise this:
+
+```bash
+node_modules/gulp/bin/gulp.js export  --outfile=/home/buddy/my-translations.csv
+```
+
+### Custom canonical language
+
+You have to set one language as canonical - that is, the reference language. By default, this is 'en', but you can change it:
+
+```bash
+node_modules/gulp/bin/gulp.js export  --canonical=es
+```
+
+## Importing back from the CSV
+
+Once your CSV has been updated, you can import it back in to overwrite your JSON.
+
+```bash
+node_modules/gulp/bin/gulp.js import
+```
+
+### Customising languages
+
+```bash
+node_modules/gulp/bin/gulp.js import --langs=en,izzle
+```
+
+### Customising the input file
+
+By default, it will import from `g11n.csv`, but if you've called the file something else, you can use that instead:
+
+```bash
+node_modules/gulp/bin/gulp.js import --infile=foo.csv
+```
+
+### Customising the output directory
+
+By default, it will write to
+
+```bash
+node_modules/gulp/bin/gulp.js import --catalogDirectory=docs
+```

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -169,6 +169,8 @@ For more information, please see [API.md](API.md).
 
 [API.md](API.md) - details of the methods available in the angular-g11n API.
 
+[managing-g11n-as-csv.md](managing-g11n-as-csv.md) - you can manage g11n using CSV files if JSON doesn't suit you.
+
 [LICENSE](../LICENSE) - terms and conditions.
 
 [CONTRIBUTING.md](../CONTRIBUTING.md) - guide to contributing to angular-g11n.

--- a/docs/sample/app/catalogs/lang-en.json
+++ b/docs/sample/app/catalogs/lang-en.json
@@ -1,10 +1,10 @@
 {
-    "lead-copy": "Simple Translations for AngularJS",
-    "brought-to-you-by": "Brought to you by",
-    "Where can I get angular-g11n?": "Where can I get angular-g11n?",
-    "hello-world": {
-        "0": "Hello {{ name }} you have no friends!",
-        "1": "Hello {{ name }} you have one friend!",
-        "n": "Hello {{ name }} you have {{ count }} friends!"
-    }
+	"lead-copy": "Simple Translations for AngularJS",
+	"brought-to-you-by": "xBrought to you by",
+	"Where can I get angular-g11n?": "Where can I get angular-g11n?",
+	"hello-world": {
+		"0": "Hello {{ name }} you have no friends!",
+		"1": "Hello {{ name }} you have one friend!",
+		"n": "Hello {{ name }} you have {{ count }} friends!"
+	}
 }

--- a/docs/sample/app/catalogs/lang-izzle.json
+++ b/docs/sample/app/catalogs/lang-izzle.json
@@ -1,11 +1,10 @@
 {
-    "lead-copy": "Sizzle Trizzle for Angulizzle",
-    "brought-to-you-by": "Brizzought to you by",
-    "Where can I get angular-g11n?": "Whizzle cizzle I gizzle angulizzle?",
-    "Switch language": "Swizzle lizzle",
-    "hello-world": {
-        "0": "Hizzle {{ name }} you hizzle no frizzle!",
-        "1": "Hizzle {{ name }} you hizzle one frizzle!",
-        "n": "Hizzle {{ name }} you hizzle {{ count }} frizzles!"
-    }
+	"lead-copy": "Sizzle Trizzle for Angulizzle",
+	"brought-to-you-by": "Brizzought to you by",
+	"Where can I get angular-g11n?": "Whizzle cizzle I gizzle angulizzle?",
+	"hello-world": {
+		"0": "Hizzle {{ name }} you hizzle no frizzle!",
+		"1": "Hizzle {{ name }} you hizzle one frizzle!",
+		"n": "Hizzle {{ name }} you hizzle {{ count }} frizzles!"
+	}
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,9 @@ var jshint = require('gulp-jshint');
 var karma = require('gulp-karma');
 var jasmine = require('gulp-jasmine');
 
+var exporter = require('./util/export-catalog');
+var importer = require('./util/import-catalog');
+
 var testFiles = [ // TODO remove?
 	'bower_components/angular/angular.js',
 	'bower_components/angular-mocks/angular-mocks.js',
@@ -10,7 +13,13 @@ var testFiles = [ // TODO remove?
 	'spec/*.js'
 ];
 
-//	TODO add import/export functionality
+gulp.task('export', function() {
+    exporter.run();
+});
+
+gulp.task('import', function() {
+    importer.run();
+});
 
 // tun tests once
 gulp.task('test', function() {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "karma-phantomjs-launcher": "~0.1.4",
     "karma-jasmine": "~0.1.5",
     "phantomjs": "~1.9.7-6",
-    "gulp-jshint": "~1.6.1"
+    "gulp-jshint": "~1.6.1",
+    "gulp-util": "~2.2.14",
+    "through2": "~0.4.2",
+    "yargs": "~1.2.2",
+    "gulp-convert": "~0.1.0"
   }
 }

--- a/util/export-catalog/index.js
+++ b/util/export-catalog/index.js
@@ -1,0 +1,138 @@
+var gutil = require('gulp-util');
+var gulp = require('gulp');
+var fs = require('fs');
+var args = require('yargs').argv;
+
+/**
+ * Gulp plugin that can export JSON g11n files to a CSV
+ */
+function exporter() {
+
+    // arguments
+    var catalogDirectory = args.inputDirectory ? args.inputDirectory : process.cwd() + '/docs/sample/app/catalogs';
+    var outfile = args.outfile ? args.outfile : 'g11n.csv';
+    var canonical = args.canonical ? args.canonical : 'en';
+    var langs = args.langs ? args.langs.split(',') : ['en'];
+
+    function readJSON(file) {
+        return require(catalogDirectory + '/' + file);
+    }
+
+    function getKeys(file) {
+        var file = readJSON(file);
+        var keys = [];
+        for (var key in file) {
+            if (file.hasOwnProperty(key)) {
+                var val = file[key];
+                if (typeof val === 'object') {
+                    for(var innerKey in val) {
+                        if (val.hasOwnProperty(innerKey)) {
+                            keys.push(key + '.' + innerKey + '__');
+                        }
+                    }
+                    continue;
+                } else {
+                    keys.push(key);
+                }
+            }
+        }
+        return keys;
+    }
+
+    function addKeysToTable(canonicalKeys) {
+        var table = {};
+        for (var i = 0; i < canonicalKeys.length; i++) {
+            var key = canonicalKeys[i];
+            table[key] = {};
+        }
+        return table;
+    }
+
+    function addLanguageToTable(table, canonicalKeys, langCode) {
+
+        function clean(val) {
+            return val.replace(/\"/g, '&quot;');
+        }
+
+        function processKey(key) {
+            var partialKey = null;
+            var baseKey = null;
+
+            var val = file[key];
+
+            if (key.substr(-2) === '__') {
+                partialKey = key.substr(key.lastIndexOf('.') + 1).replace('__', '');
+                baseKey = key.substr(0, key.lastIndexOf('.'));
+                val = file[baseKey];
+            }
+
+            if (typeof val === 'undefined') {
+                table[key][langCode] = '';
+            } else {
+                if (typeof val === 'object') {
+                    for(var innerKey in val) {
+                        if (val.hasOwnProperty(innerKey)) {
+                            if (innerKey === partialKey) {
+                                var tmpkey = baseKey + '.' + innerKey + '__';
+                                table[key][langCode] = clean(val[innerKey]);
+                            }
+                        }
+                    }
+                } else {
+                    table[key][langCode] = clean(val);
+                }
+            }
+        }
+
+        gutil.log("Reading language " + langCode + " from " + catalogDirectory + '/lang-' + langCode + '.json');
+        var file = readJSON('lang-' + langCode + '.json');
+        for (var i = 0; i < canonicalKeys.length; i++) {
+            var key = canonicalKeys[i];
+            processKey(key);
+        }
+    }
+
+    // there is probably some way a million times better to do this but I couldn't get any of the fiddly libraries
+    // to work
+    function renderAsCSV(table, langs) {
+        var string = '"Key"';
+
+        for(var i = 0; i < langs.length; i++) {
+            var lang = langs[i];
+            string += ',"' + lang + '"';
+        }
+
+        for (var i = 0; i < canonicalKeys.length; i++) {
+            var key = canonicalKeys[i];
+            string += "\n" + '"' + key + '"';
+            for(var j = 0; j < langs.length; j++) {
+                var lang = langs[j];
+                string += ',"' + table[key][lang] + '"';
+            }
+        }
+
+        return string;
+    }
+
+    var canonicalKeys = getKeys('lang-' + canonical + '.json');
+    var table = addKeysToTable(canonicalKeys);
+    for(var i = 0; i < langs.length; i++) {
+        var lang = langs[i];
+        addLanguageToTable(table, canonicalKeys, lang);
+    }
+
+    var csv = renderAsCSV(table, langs);
+
+    fs.writeFile(outfile, csv, function(err) {
+        if(err) {
+            gutil.log(err);
+        } else {
+            gutil.log("g11n file was saved to " + outfile);
+        }
+    });
+}
+
+// Exporting the plugin main function
+module.exports = {
+    run: exporter
+};

--- a/util/import-catalog/index.js
+++ b/util/import-catalog/index.js
@@ -1,0 +1,74 @@
+var gutil = require('gulp-util');
+var gulp = require('gulp');
+var fs = require('fs');
+var args = require('yargs').argv;
+var convert = require('gulp-convert');
+
+var infile = args.infile ? args.infile : 'g11n.csv';
+
+/**
+ * Gulp plugin that can import JSON g11n files from a CSV
+ */
+function importer() {
+    var catalogDirectory = args.outputDirectory ? args.outputDirectory : process.cwd() + '/docs/sample/app/catalogs';
+    var langs = args.langs ? args.langs.split(',') : ['en'];
+
+    gulp.src([infile])
+        .pipe(convert({
+            from: 'csv',
+            to: 'json'
+        }))
+        .pipe(gulp.dest('.'));
+
+    // convert to JSON first, then the CSV can be read in
+    gutil.log("Open " + process.cwd() + '/' + infile);
+    var jsonFile = infile.replace('.csv', '.json');
+
+    var file = require( process.cwd() + '/' + jsonFile);
+
+    function dirty(val) {
+        return val.replace(/&quot;/, '\n');
+    }
+
+    for (var j = 0; j < langs.length; j++) {
+        var lang = langs[j];
+        var output = {};
+        for (var i = 0 ; i < file.length; i++) {
+            var key = file[i].Key;
+            var value = file[i][lang];
+            if (key.substr(-2) === '__') {
+                var partialKey = key.substr(key.lastIndexOf('.') + 1).replace('__', '');
+                key = key.substr(0, key.lastIndexOf('.'));
+                if (typeof output[key] !== 'object') {
+                    output[key] = {};
+                }
+                output[key][partialKey] = dirty(value);
+            } else {
+                output[key] = dirty(value);
+            }
+        }
+
+        var outfile = catalogDirectory + '/lang-' + lang + '.json';
+        gutil.log('Writing g11n file to ' + outfile + '...');
+        fs.writeFile(outfile, JSON.stringify(output, null, '\t'), function(err) {
+            if(err) {
+                gutil.log(err);
+            }
+        });
+    }
+
+    gutil.log("All done! Run git diff to see what files have changed. Please check changes carefully.");
+}
+
+// Exporting the plugin main function
+module.exports = {
+    run: function() {
+        gulp.src([infile])
+            .pipe(convert({
+                from: 'csv',
+                to: 'json'
+            }))
+            .pipe(gulp.dest('.'))
+            .on('close', importer);
+    }
+};


### PR DESCRIPTION
Two Gulp tasks, import and export, that allow the JSON to be exported to a CSV and imported back in. Customisable as to which paths are used.

This is a first iteration. Ideally, the import/export would be decoupled from this repository - at the moment, it would be a bit fiddly to use perhaps?
